### PR TITLE
[feat] Separating the factory logic into an independent class

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -3,12 +3,15 @@ class DialogYamlException(RuntimeError):
         self.message = message
         super().__init__(message)
 
+    def __str__(self):
+        return self.message
+
 
 class ModelRegistrationError(DialogYamlException):
     def __init__(self, tag, model_class, message):
         self.tag = tag
         self._class = model_class
-        message.format(tag=tag, model_class=model_class)
+        message = message.format(tag=tag, model_class=model_class)
         super().__init__(message)
 
 
@@ -65,12 +68,12 @@ class CategoryNotFoundError(DialogYamlException):
 class InvalidTagName(DialogYamlException):
     def __init__(self, tag: str, message: str):
         self.tag = tag
-        message.format(tag=tag)
+        message = message.format(tag=tag)
         super().__init__(message)
 
 
 class InvalidTagDataType(DialogYamlException):
     def __init__(self, tag: str, message: str):
         self.tag = tag
-        message.format(tag=tag)
+        message = message.format(tag=tag)
         super().__init__(message)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,6 +1,6 @@
-"""The `core.models` module provides the YAMLModel class for creating YAML models.
+"""The `core.models` module provides the `YAMLModelFactory` class for creating YAML models.
 
-YAMLModel is a subclass of Pydantic BaseModel and offers functionality for working with YAML data
+`YAMLModelFactory` class offers functionality for working with YAML data
 and creating instances of custom model classes based on the YAML data.
 
 Features:
@@ -11,39 +11,49 @@ Features:
 
 Classes:
 -----------
-- YAMLModel: Static class for creating YAML models.
+- YAMLModelFactory: Static class for creating YAML models.
 """
 
 import logging
 import re
 from typing import Type, Union, Dict, Any
 
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError, BaseModel
 
 from core.exceptions import ModelRegistrationError, InvalidTagName, DialogYamlException
+from core.models.base import YAMLModel
 
 logger = logging.getLogger(__name__)
 
 
-class YAMLModel(BaseModel):
-    """Static class for creating YAML models.
-
-    The `YAMLModel` class is a subclass of `BaseModel` from the Pydantic library.
-    It provides functionality for working with YAML data and creating instances
-    of custom model classes based on the YAML data.
+class YAMLModelFactory:
+    """The `YAMLModelFactory` class is a static class that provides functionality
+    for working with YAML data and creating instances of custom model classes based on the YAML data.
+    It allows the registration of custom model classes with unique tags
+    and supports the retrieval of the registered model class based on the tag.
 
     - Allows the registration of custom model classes with unique tags.
     - Provides a method to create instances of custom model classes from YAML data.
     - Supports the retrieval of the registered model class based on the tag.
 
     :ivar _models_classes: A dictionary that maps tag to model class.
-    :vartype _models_classes: Dict[str, Type['YAMLModel']]
+    :vartype _models_classes: Dict[str, Type[YAMLModel]]
     """
 
-    _models_classes: Dict[str, Type['YAMLModel']] = {}
+    _models_classes: Dict[str, Type[YAMLModel]] = {}
 
     @classmethod
     def is_valid_tag(cls, tag: str) -> bool:
+        """Check if the given tag is a valid tag.
+
+        :param tag: The tag to be checked.
+        :type tag: str
+
+        :return: True if the tag is valid, False otherwise.
+        :rtype: bool
+
+        :raises InvalidTagName: When the tag is invalid
+        """
         if not tag or not isinstance(tag, str):
             raise InvalidTagName(tag, '{tag!r} must be non-empty string')
 
@@ -56,29 +66,52 @@ class YAMLModel(BaseModel):
         return True
 
     @classmethod
-    def is_valid_model_class(cls, tag: str, model_class: Type['YAMLModel']) -> bool:
-        if not isinstance(model_class, YAMLModel.__class__):
+    def is_valid_model_class(cls, tag: str, model_class: Union[Type[YAMLModel], Type[BaseModel]]) -> bool:
+        """Check if the given model class is a valid model class for the specified tag.
+
+        :param tag: The tag associated with the model class.
+        :type tag: str
+        :param model_class: The model class to be checked.
+        :type model_class: Union[Type[YAMLModel], Type[BaseModel]]
+
+        :return: True if the model class is valid, False otherwise.
+        :rtype: bool
+
+        :raises ModelRegistrationError: When a model is not a valid model class.
+        """
+
+        if not model_class or not issubclass(model_class, (YAMLModel, BaseModel)):
             raise ModelRegistrationError(
                 tag, model_class,
-                message='{model_class!r} must be type of YAMLModel'
+                message='{model_class!r} mapped to {tag!r} must be type of YAMLModel or BaseModel'
             )
 
         return True
 
     @classmethod
-    def _is_valid(cls, tag: str, model_class: Type['YAMLModel']) -> bool:
+    def _is_valid(cls, tag: str, model_class: Union[Type[YAMLModel], Type[BaseModel]]) -> bool:
+        """Check if the given tag is valid for the specified model class.
+
+        :param tag: The tag associated with the model class.
+        :type tag: str
+        :param model_class: The model class to be checked.
+        :type model_class: Type[YAMLModel]
+
+        :return: True if the tag is valid, False otherwise.
+        :rtype: bool
+        """
         cls.is_valid_tag(tag)
         cls.is_valid_model_class(tag, model_class)
         return True
 
     @classmethod
-    def add_model_class(cls, tag: str, model_class: Type['YAMLModel']):
+    def add_model_class(cls, tag: str, model_class: Type[YAMLModel]):
         """Registers a custom model class with a unique tag.
 
         :param tag: A unique tag for the custom model class.
         :type tag: Str
         :param model_class: The custom model class to be registered.
-        :type model_class: Type['YAMLModel']
+        :type model_class: Type[YAMLModel]
 
         :raises ModelRegistrationError: When a model with the same tag has already been registered.
         """
@@ -94,24 +127,24 @@ class YAMLModel(BaseModel):
             cls._models_classes[tag] = model_class
 
     @classmethod
-    def get_model_class(cls, tag: str) -> Union[Type['YAMLModel'], None]:
+    def get_model_class(cls, tag: str) -> Union[Type[YAMLModel], None]:
         """Retrieves a registered custom model class based on its tag.
 
         :param tag: The tag of the custom model class to retrieve.
         :type tag: Str
 
         :return: The custom model class associated with the given tag or None if not found.
-        :rtype: Type['YAMLModel'] or None
+        :rtype: Type[YAMLModel] or None
         """
         logger.debug(f'Get class for tag {tag!r}')
         return cls._models_classes.get(tag)
 
     @classmethod
-    def set_classes(cls, models_classes: Dict[str, Type['YAMLModel']]) -> None:
+    def set_classes(cls, models_classes: Dict[str, Type[YAMLModel]]) -> None:
         """Sets the registered custom model classes.
 
         :param models_classes: A dictionary of custom model classes with their tags.
-        :type models_classes: Dict[str, Type['YAMLModel']]
+        :type models_classes: Dict[str, Type[YAMLModel]]
 
         :raises DialogYamlException: When `models_classes` is not a valid dictionary of model classes.
         """
@@ -124,26 +157,18 @@ class YAMLModel(BaseModel):
         cls._models_classes = models_classes
 
     @classmethod
-    def from_data(cls, yaml_data: Dict[str, Any]) -> 'YAMLModel':
+    def create_model(cls, yaml_data: Dict[str, Any]) -> YAMLModel:
         """Creates an instance of a custom model class based on YAML data.
 
-        The `from_data` method in the `YAMLModel` class is used to create an instance
-        of a custom model class based on YAML data.
-
-        It retrieves the model class based on the tag provided in the YAML data
-        and then creates an instance of that class using the data associated with the tag.
-
         :param yaml_data: A dictionary representing the YAML data.
-            The keys in the dictionary are the tags, and the
-            values are the associated data for each tag.
         :type yaml_data: Dict[str, Any]
 
         :return: An instance of the custom model class based on the existing class
-            in the `cls._models_classes`, founded by `tag` in `yaml_data`.
+            in the `YAMLModelFabric._models_classes`, founded by `tag` in `yaml_data`.
         :rtype: YAMLModel
 
         :raises DialogYamlException: When `yaml_data` is `None` or an empty dictionary.
-        :raises InvalidTagName: When a tag key does not exist in the `cls._models_classes`.
+        :raises InvalidTagName: When a tag key does not exist in the `YAMLModelFabric._models_classes`.
         """
         if not yaml_data or not isinstance(yaml_data, dict):
             raise DialogYamlException("yaml_data must be a non-empty dictionary")

--- a/core/models/base.py
+++ b/core/models/base.py
@@ -1,16 +1,29 @@
+from abc import ABC, abstractmethod
 from typing import Any
 
-from pydantic import ConfigDict
+from aiogram_dialog.api.internal import Widget
+from pydantic import ConfigDict, BaseModel
 
-from core.models import YAMLModel
 from core.models.funcs import FuncField
 
 
-class WidgetModel(YAMLModel):
+class YAMLModel(BaseModel, ABC):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra='allow'
     )
+
+    @classmethod
+    @abstractmethod
+    def to_model(cls, data: Any) -> 'YAMLModel': pass
+
+    @abstractmethod
+    def to_object(self) -> Widget: pass
+
+
+class WidgetModel(YAMLModel):
+    def to_object(self):
+        raise NotImplementedError()
 
     when: FuncField = None
 

--- a/core/models/dialog.py
+++ b/core/models/dialog.py
@@ -4,12 +4,12 @@ from aiogram_dialog import LaunchMode, Dialog
 from pydantic import field_validator
 
 from core.models.funcs import FuncField
-from core.models.base import WidgetModel
+from core.models.base import YAMLModel
 from core.utils import clean_empty
 
 
-class DialogModel(WidgetModel):
-    windows: list[WidgetModel]
+class DialogModel(YAMLModel):
+    windows: list[YAMLModel]
     on_start: FuncField = None
     on_close: FuncField = None
     on_process_result: FuncField = None
@@ -17,7 +17,7 @@ class DialogModel(WidgetModel):
     getter: FuncField = None
     preview_data: FuncField = None
 
-    def get_obj(self) -> Dialog:
+    def to_object(self) -> Dialog:
         kwargs = clean_empty(dict(
             on_start=self.on_start.func if self.on_start else None,
             on_close=self.on_close.func if self.on_close else None,
@@ -27,7 +27,7 @@ class DialogModel(WidgetModel):
             preview_data=self.preview_data.func if self.getter else None
         ))
         return Dialog(
-            *[window.get_obj() for window in self.windows],
+            *[window.to_object() for window in self.windows],
             **kwargs
         )
 

--- a/core/models/widgets/calendars/calendar.py
+++ b/core/models/widgets/calendars/calendar.py
@@ -11,7 +11,7 @@ class CalendarModel(WidgetModel):
     id: str = None
     on_click: FuncField = None
 
-    def get_obj(self) -> Calendar:
+    def to_object(self) -> Calendar:
         kwargs = clean_empty(dict(
             id=self.id,
             on_click=self.on_click.func if self.on_click else None,

--- a/core/models/widgets/counters/counter.py
+++ b/core/models/widgets/counters/counter.py
@@ -15,7 +15,7 @@ class ProgressModel(WidgetModel):
     filled: TextField = None
     empty: TextField = None
 
-    def get_obj(self) -> Progress:
+    def to_object(self) -> Progress:
         kwargs = clean_empty(dict(
             field=self.field.val,
             width=self.width,
@@ -47,12 +47,12 @@ class CounterModel(WidgetModel):
     on_text_click: FuncField = None
     on_value_changed: FuncField = None
 
-    def get_obj(self) -> Counter:
+    def to_object(self) -> Counter:
         kwargs = clean_empty(dict(
             id=self.id,
-            plus=self.plus.get_obj() if self.plus else None,
-            minus=self.minus.get_obj() if self.minus else None,
-            text=self.text.get_obj() if self.text else None,
+            plus=self.plus.to_object() if self.plus else None,
+            minus=self.minus.to_object() if self.minus else None,
+            text=self.text.to_object() if self.text else None,
             min_value=self.min_value,
             max_value=self.max_value,
             increment=self.increment,

--- a/core/models/widgets/inputs/input.py
+++ b/core/models/widgets/inputs/input.py
@@ -14,7 +14,7 @@ class MessageInputModel(WidgetModel):
     filter: FuncField = None
     content_types: list[ContentType] = [ContentType.ANY]
 
-    def get_obj(self) -> MessageInput:
+    def to_object(self) -> MessageInput:
         kwargs = clean_empty(dict(
             func=self.func.func if self.func else None,
             filter=self.filter.func if self.filter else None,

--- a/core/models/widgets/medias/media.py
+++ b/core/models/widgets/medias/media.py
@@ -16,10 +16,10 @@ class StaticMediaModel(WidgetModel):
     use_pipe: bool = False
     media_params: dict[str, Any] = None
 
-    def get_obj(self) -> StaticMedia:
+    def to_object(self) -> StaticMedia:
         kwargs = clean_empty(dict(
-            path=self.path.get_obj() if self.path else None,
-            url=self.uri.get_obj() if self.uri else None,
+            path=self.path.to_object() if self.path else None,
+            url=self.uri.to_object() if self.uri else None,
             type=self.type,
             use_pipe=self.use_pipe,
             media_params=self.media_params,
@@ -44,7 +44,7 @@ class StaticMediaModel(WidgetModel):
 class DynamicMediaModel(WidgetModel):
     selector: str
 
-    def get_obj(self) -> DynamicMedia:
+    def to_object(self) -> DynamicMedia:
         kwargs = clean_empty(dict(
             when=self.when.func if self.when else None,
             selector=self.selector

--- a/core/models/widgets/scrolls/scroll.py
+++ b/core/models/widgets/scrolls/scroll.py
@@ -27,11 +27,11 @@ class ScrollingTextModel(WidgetModel):
     page_size: int = 0
     on_page_changed: FuncField = None
 
-    def get_obj(self) -> ScrollingText:
+    def to_object(self) -> ScrollingText:
         kwargs = clean_empty(dict(
             id=self.id,
             page_size=self.page_size,
-            text=self.text.get_obj(),
+            text=self.text.to_object(),
             on_page_changed=self.on_page_changed.func if self.on_page_changed else None,
             when=self.when.func if self.when else None
         ))
@@ -49,7 +49,7 @@ class StubScrollModel(WidgetModel):
     pages: Union[str, int, FuncField]
     on_page_changed: FuncField = None
 
-    def get_obj(self) -> StubScroll:
+    def to_object(self) -> StubScroll:
         kwargs = clean_empty(dict(
             id=self.id,
             pages=self.pages.func if isinstance(self.pages, FuncModel) else self.pages,
@@ -70,12 +70,12 @@ class NumberedPagerModel(WidgetModel):
     page_text: TextField = DEFAULT_PAGE_TEXT
     current_page_text: TextField = DEFAULT_CURRENT_PAGE_TEXT
 
-    def get_obj(self) -> NumberedPager:
+    def to_object(self) -> NumberedPager:
         kwargs = clean_empty(dict(
             id=self.id,
             scroll=self.scroll,
-            page_text=self.page_text.get_obj(),
-            current_page_text=self.current_page_text.get_obj(),
+            page_text=self.page_text.to_object(),
+            current_page_text=self.current_page_text.to_object(),
             when=self.when.func if self.when else None
         ))
         return NumberedPager(**kwargs)
@@ -95,12 +95,12 @@ class SwitchPageModel(WidgetModel):
     page: Union[int, PageDirection]
     scroll: str
 
-    def get_obj(self) -> SwitchPage:
+    def to_object(self) -> SwitchPage:
         kwargs = clean_empty(dict(
             id=self.id,
             page=self.page,
             scroll=self.scroll,
-            text=self.text.get_obj() if self.text else None,
+            text=self.text.to_object() if self.text else None,
             when=self.when.func if self.when else None
         ))
         return SwitchPage(**kwargs)

--- a/core/models/widgets/selects/select.py
+++ b/core/models/widgets/selects/select.py
@@ -16,10 +16,10 @@ class CheckboxModel(WidgetModel):
     unchecked: TextField = TextField(val='[ ] Unchecked')
     default: bool = True
 
-    def get_obj(self) -> Checkbox:
+    def to_object(self) -> Checkbox:
         args = [
-            self.checked.get_obj(),
-            self.unchecked.get_obj(),
+            self.checked.to_object(),
+            self.unchecked.to_object(),
         ]
         kwargs = clean_empty(dict(
             id=self.id,
@@ -46,14 +46,14 @@ class SelectModel(WidgetModel):
     item_id_getter: Union[int, str]
     on_click: FuncField = None
 
-    def get_obj(self) -> Select:
+    def to_object(self) -> Select:
         item_id_getter = self.item_id_getter
         if isinstance(item_id_getter, int):
             item_id_getter = operator.itemgetter(item_id_getter)
         if isinstance(item_id_getter, str):
             item_id_getter = FuncModel.to_model(item_id_getter).func
         kwargs = clean_empty(dict(
-            text=self.text.get_obj(),
+            text=self.text.to_object(),
             id=self.id,
             items=self.items,
             item_id_getter=item_id_getter,
@@ -80,10 +80,10 @@ class RadioModel(WidgetModel):
     unchecked: TextField = TextField(val='{item}')
     item_id_getter: Union[int, str, FuncField]
 
-    def get_obj(self) -> Radio:
+    def to_object(self) -> Radio:
         args = [
-            self.checked.get_obj(),
-            self.unchecked.get_obj(),
+            self.checked.to_object(),
+            self.unchecked.to_object(),
         ]
         item_id_getter = self.item_id_getter
         if isinstance(item_id_getter, int):
@@ -115,15 +115,15 @@ class MultiSelectModel(SelectModel, CheckboxModel):
     checked: TextField = TextField(val='✓ {item[0]}', formatted=True)
     unchecked: TextField = TextField(val='{item[0]}', formatted=True)
 
-    def get_obj(self) -> Multiselect:
+    def to_object(self) -> Multiselect:
         item_id_getter = self.item_id_getter
         if isinstance(item_id_getter, int):
             item_id_getter = operator.itemgetter(item_id_getter)
         if isinstance(item_id_getter, str):
             item_id_getter = FuncModel.to_model(item_id_getter).func
         kwargs = clean_empty(dict(
-            checked_text=self.checked.get_obj(),
-            unchecked_text=self.unchecked.get_obj(),
+            checked_text=self.checked.to_object(),
+            unchecked_text=self.unchecked.to_object(),
             id=self.id,
             items=self.items,
             item_id_getter=item_id_getter,

--- a/core/models/window.py
+++ b/core/models/window.py
@@ -4,14 +4,14 @@ from aiogram.enums import ParseMode
 from aiogram_dialog import Window
 from pydantic import field_validator
 
-from core.models.base import WidgetModel
+from core.models.base import YAMLModel, WidgetModel
 from core.models.funcs import FuncField
 from core.models.widgets.kbd import GroupKeyboardField
 from core.states import YAMLStatesBuilder
 from core.utils import clean_empty
 
 
-class WindowModel(WidgetModel):
+class WindowModel(YAMLModel):
     widgets: list[WidgetModel]
     state: str
     getter: FuncField = None
@@ -20,7 +20,7 @@ class WindowModel(WidgetModel):
     preview_add_transitions: GroupKeyboardField = None
     preview_data: FuncField = None
 
-    def get_obj(self) -> Window:
+    def to_object(self) -> Window:
         kwargs = clean_empty(dict(
             state=YAMLStatesBuilder().get_by_name(self.state),
             getter=self.getter.func if self.getter else None,
@@ -30,7 +30,7 @@ class WindowModel(WidgetModel):
             preview_data=self.preview_data.func if self.preview_data else None
         ))
         return Window(
-            *[widget.get_obj() for widget in self.widgets],
+            *[widget.to_object() for widget in self.widgets],
             **kwargs
         )
 

--- a/examples/mega/bot/custom/calendars.py
+++ b/examples/mega/bot/custom/calendars.py
@@ -64,7 +64,7 @@ class CustomCalendar(Calendar):
 
 
 class CustomCalendarModel(CalendarModel):
-    def get_obj(self) -> CustomCalendar:
+    def to_object(self) -> CustomCalendar:
         kwargs = clean_empty(dict(
             id=self.id,
             on_click=self.on_click.func if self.on_click else None,

--- a/test/models/test_model_factory.py
+++ b/test/models/test_model_factory.py
@@ -1,16 +1,21 @@
+from typing import Self
+
 import pytest
-from pydantic import BaseModel
+from aiogram_dialog.api.internal import Widget
 
 from core.exceptions import ModelRegistrationError, InvalidTagName, DialogYamlException
-from core.models import YAMLModel
+from core.models import YAMLModelFactory, YAMLModel
 
 
 class YAMLSubModel(YAMLModel):
+    def to_object(self) -> Widget:
+        pass
+
     key1: str
     key2: str = None
 
     @classmethod
-    def to_model(cls, data: dict):
+    def to_model(cls, data: dict) -> Self:
         return YAMLSubModel(**data)
 
 
@@ -26,7 +31,7 @@ class NotYAMLModel:
 class TestYAMLModelClass:
     @pytest.fixture(autouse=True)
     def setup(self):
-        YAMLModel._models_classes = {}
+        YAMLModelFactory._models_classes = {}
 
 
 class TestIsValidModelClass(TestYAMLModelClass):
@@ -36,7 +41,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
         model_class = YAMLModel
 
         # When
-        result = YAMLModel._is_valid(tag, model_class)
+        result = YAMLModelFactory._is_valid(tag, model_class)
 
         # Then
         assert result is True
@@ -47,7 +52,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
         model_class = YAMLModel
 
         # When
-        result = YAMLModel._is_valid(tag, model_class)
+        result = YAMLModelFactory._is_valid(tag, model_class)
 
         # Then
         assert result is True
@@ -58,7 +63,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
         model_class = YAMLModel
 
         # When
-        result = YAMLModel._is_valid(tag, model_class)
+        result = YAMLModelFactory._is_valid(tag, model_class)
 
         # Then
         assert result is True
@@ -69,7 +74,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
         model_class = YAMLModel
 
         # When
-        result = YAMLModel._is_valid(tag, model_class)
+        result = YAMLModelFactory._is_valid(tag, model_class)
 
         # Then
         assert result is True
@@ -80,7 +85,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
         model_class = YAMLModel
 
         # When
-        result = YAMLModel._is_valid(tag, model_class)
+        result = YAMLModelFactory._is_valid(tag, model_class)
 
         # Then
         assert result is True
@@ -92,7 +97,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
 
         # When, Then
         with pytest.raises(InvalidTagName):
-            YAMLModel._is_valid(tag, model_class)
+            YAMLModelFactory._is_valid(tag, model_class)
 
     def test_non_string_tag_raises_invalid_tag_name(self):
         # Given
@@ -101,7 +106,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
 
         # When, Then
         with pytest.raises(InvalidTagName):
-            YAMLModel._is_valid(tag, model_class)
+            YAMLModelFactory._is_valid(tag, model_class)
 
     def test_tag_with_only_digits_raises_invalid_tag_name(self):
         # Given
@@ -110,7 +115,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
 
         # When, Then
         with pytest.raises(InvalidTagName):
-            YAMLModel._is_valid(tag, model_class)
+            YAMLModelFactory._is_valid(tag, model_class)
 
     def test_tag_with_special_characters_raises_invalid_tag_name(self):
         # Given
@@ -119,7 +124,7 @@ class TestIsValidModelClass(TestYAMLModelClass):
 
         # When, Then
         with pytest.raises(InvalidTagName):
-            YAMLModel._is_valid(tag, model_class)
+            YAMLModelFactory._is_valid(tag, model_class)
 
 
 class TestSetModelClasses(TestYAMLModelClass):
@@ -132,30 +137,30 @@ class TestSetModelClasses(TestYAMLModelClass):
         }
 
         # When
-        YAMLModel.set_classes(models_classes)
+        YAMLModelFactory.set_classes(models_classes)
 
         # Then
-        assert YAMLModel._models_classes == models_classes
+        assert YAMLModelFactory._models_classes == models_classes
 
     def test_set_empty_dictionary_of_model_classes(self):
         # Given
         models_classes = {}
 
         # When
-        YAMLModel.set_classes(models_classes)
+        YAMLModelFactory.set_classes(models_classes)
 
         # Then
-        assert YAMLModel._models_classes == models_classes
+        assert YAMLModelFactory._models_classes == models_classes
 
     def test_set_dictionary_with_non_string_key(self):
         # Given
         models_classes = {
-            123: YAMLModel
+            123: YAMLModelFactory
         }
 
         # When/Then
         with pytest.raises(DialogYamlException):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
     def test_set_dictionary_with_non_yamlmodel_value(self):
         # Given
@@ -165,27 +170,27 @@ class TestSetModelClasses(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(DialogYamlException):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
     def test_set_dictionary_with_key_only_digits(self):
         # Given
         models_classes = {
-            '123': YAMLModel
+            '123': YAMLModelFactory
         }
 
         # When/Then
         with pytest.raises(InvalidTagName):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
     def test_set_dictionary_with_key_special_characters(self):
         # Given
         models_classes = {
-            'tag!': YAMLModel
+            'tag!': YAMLModelFactory
         }
 
         # When/Then
         with pytest.raises(InvalidTagName):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
     def test_raise_dialog_yaml_exception_when_models_classes_not_dictionary(self):
         # Given
@@ -193,18 +198,18 @@ class TestSetModelClasses(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(DialogYamlException):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
     def test_raise_dialog_yaml_exception_when_models_classes_not_dictionary_of_strings_to_yamlmodel_classes(self):
         # Given
         models_classes = {
-            'tag1': YAMLModel,
+            'tag1': YAMLModelFactory,
             'tag2': 'NotYAMLModel'
         }
 
         # When/Then
         with pytest.raises(DialogYamlException):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
     def test_raise_dialog_yaml_exception_when_models_classes_is_none(self):
         # Given
@@ -212,7 +217,7 @@ class TestSetModelClasses(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(DialogYamlException):
-            YAMLModel.set_classes(models_classes)
+            YAMLModelFactory.set_classes(models_classes)
 
 
 class TestRegisterModelClass(TestYAMLModelClass):
@@ -223,10 +228,10 @@ class TestRegisterModelClass(TestYAMLModelClass):
         model_class1 = YAMLModel
 
         # When
-        YAMLModel.add_model_class(tag, model_class1)
+        YAMLModelFactory.add_model_class(tag, model_class1)
 
         # Then
-        assert YAMLModel.get_model_class(tag) == model_class1
+        assert YAMLModelFactory.get_model_class(tag) == model_class1
 
     def test_register_multiple_custom_model_classes_with_unique_tags(self):
         # Given
@@ -236,12 +241,12 @@ class TestRegisterModelClass(TestYAMLModelClass):
         model_class2 = YAMLSubModel
 
         # When
-        YAMLModel.add_model_class(tag1, model_class1)
-        YAMLModel.add_model_class(tag2, model_class2)
+        YAMLModelFactory.add_model_class(tag1, model_class1)
+        YAMLModelFactory.add_model_class(tag2, model_class2)
 
         # Then
-        assert YAMLModel.get_model_class(tag1) == model_class1
-        assert YAMLModel.get_model_class(tag2) == model_class2
+        assert YAMLModelFactory.get_model_class(tag1) == model_class1
+        assert YAMLModelFactory.get_model_class(tag2) == model_class2
 
     def test_register_custom_model_class_with_previously_registered_tag_and_different_class(self):
         # Given
@@ -250,11 +255,11 @@ class TestRegisterModelClass(TestYAMLModelClass):
         model_class2 = YAMLSubModel
 
         # When
-        YAMLModel.add_model_class(tag, model_class1)
+        YAMLModelFactory.add_model_class(tag, model_class1)
 
         # Then
         with pytest.raises(ModelRegistrationError):
-            YAMLModel.add_model_class(tag, model_class2)
+            YAMLModelFactory.add_model_class(tag, model_class2)
 
     def test_register_custom_model_class_with_tag_containing_special_characters(self):
         # Given
@@ -263,7 +268,7 @@ class TestRegisterModelClass(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(InvalidTagName):
-            YAMLModel.add_model_class(tag, model_class)
+            YAMLModelFactory.add_model_class(tag, model_class)
 
     def test_register_custom_model_class_with_empty_tag(self):
         # Given
@@ -272,7 +277,7 @@ class TestRegisterModelClass(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(InvalidTagName):
-            YAMLModel.add_model_class(tag, model_class)
+            YAMLModelFactory.add_model_class(tag, model_class)
 
     def test_register_custom_model_class_with_non_string_tag(self):
         # Given
@@ -281,7 +286,7 @@ class TestRegisterModelClass(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(InvalidTagName):
-            YAMLModel.add_model_class(tag, model_class)
+            YAMLModelFactory.add_model_class(tag, model_class)
 
     def test_register_custom_model_class_with_already_registered_tag(self):
         # Given
@@ -290,11 +295,11 @@ class TestRegisterModelClass(TestYAMLModelClass):
         model_class2 = YAMLSubModel
 
         # When
-        YAMLModel.add_model_class(tag, model_class1)
+        YAMLModelFactory.add_model_class(tag, model_class1)
 
         # Then
         with pytest.raises(ModelRegistrationError):
-            YAMLModel.add_model_class(tag, model_class2)
+            YAMLModelFactory.add_model_class(tag, model_class2)
 
     def test_register_custom_model_class_with_none_tag(self):
         # Given
@@ -303,7 +308,7 @@ class TestRegisterModelClass(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(InvalidTagName):
-            YAMLModel.add_model_class(tag, model_class)
+            YAMLModelFactory.add_model_class(tag, model_class)
 
 
 class TestGetModelClass(TestYAMLModelClass):
@@ -311,10 +316,10 @@ class TestGetModelClass(TestYAMLModelClass):
         # Given
         tag = 'tag'
         model_class = YAMLModel
-        YAMLModel._models_classes = {tag: model_class}
+        YAMLModelFactory._models_classes = {tag: model_class}
 
         # When
-        result = YAMLModel.get_model_class(tag)
+        result = YAMLModelFactory.get_model_class(tag)
 
         # Then
         assert result == model_class
@@ -324,7 +329,7 @@ class TestGetModelClass(TestYAMLModelClass):
         tag = 'tag'
 
         # When
-        result = YAMLModel.get_model_class(tag)
+        result = YAMLModelFactory.get_model_class(tag)
 
         # Then
         assert result is None
@@ -334,7 +339,7 @@ class TestFromDataModelClass(TestYAMLModelClass):
     @pytest.fixture(autouse=True)
     def setup(self):
         tag = 'test'
-        YAMLModel.set_classes({tag: YAMLSubModel})
+        YAMLModelFactory.set_classes({tag: YAMLSubModel})
 
     def test_to_model(self):
         # Given
@@ -344,7 +349,7 @@ class TestFromDataModelClass(TestYAMLModelClass):
         }}
 
         # When
-        result = YAMLModel.from_data(data)
+        result = YAMLModelFactory.create_model(data)
 
         # Then
         assert isinstance(result, YAMLSubModel)
@@ -358,7 +363,7 @@ class TestFromDataModelClass(TestYAMLModelClass):
         }}
 
         # When
-        result = YAMLModel.from_data(data)
+        result = YAMLModelFactory.create_model(data)
 
         # Then
         assert isinstance(result, YAMLSubModel)
@@ -370,7 +375,7 @@ class TestFromDataModelClass(TestYAMLModelClass):
         tag = 'test'
 
         # When
-        result = YAMLModel.get_model_class(tag)
+        result = YAMLModelFactory.get_model_class(tag)
 
         # Then
         assert result == YAMLSubModel
@@ -381,4 +386,4 @@ class TestFromDataModelClass(TestYAMLModelClass):
 
         # When/Then
         with pytest.raises(DialogYamlException):
-            YAMLModel.from_data(data)
+            YAMLModelFactory.create_model(data)

--- a/test/models/widgets/conftest.py
+++ b/test/models/widgets/conftest.py
@@ -3,7 +3,7 @@ from typing import Union, Callable, Awaitable
 import pytest
 
 from core import models_classes
-from core.models import YAMLModel
+from core.models import YAMLModelFactory
 from core.models.funcs import FuncRegistry
 from core.states import YAMLStatesBuilder
 
@@ -68,7 +68,7 @@ class TestWidgetBase:
 
     @pytest.fixture(autouse=True)
     def setup(self, func_registry, states_builder):
-        self.yaml_model = YAMLModel
+        self.yaml_model = YAMLModelFactory
         self.yaml_model.set_classes(models_classes)
         self.func_registry = func_registry
         self.states_builder = states_builder

--- a/test/models/widgets/test_calendars.py
+++ b/test/models/widgets/test_calendars.py
@@ -11,8 +11,8 @@ class TestCalendar(TestWidgetBase):
          CalendarModel, Calendar),
     ])
     def test_calendar(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_counters.py
+++ b/test/models/widgets/test_counters.py
@@ -24,8 +24,8 @@ class TestCounters(TestWidgetBase):
          CounterModel, Counter),
     ])
     def test_counters(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_input.py
+++ b/test/models/widgets/test_input.py
@@ -19,8 +19,8 @@ class TestInput(TestWidgetBase):
          MessageInputModel, MessageInput),
     ])
     def test_input(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_keyboards.py
+++ b/test/models/widgets/test_keyboards.py
@@ -110,8 +110,8 @@ class TestKeyboard(TestWidgetBase):
          ScrollingGroupKeyboardModel, ScrollingGroup),
     ])
     def test_keyboard(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_medias.py
+++ b/test/models/widgets/test_medias.py
@@ -18,8 +18,8 @@ class TestMedias(TestWidgetBase):
          DynamicMediaModel, DynamicMedia),
     ])
     def test_medias(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_scrolls.py
+++ b/test/models/widgets/test_scrolls.py
@@ -39,8 +39,8 @@ class TestScroll(TestWidgetBase):
          LastPageModel, SwitchPage),
     ])
     def test_scroll(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_selects.py
+++ b/test/models/widgets/test_selects.py
@@ -43,8 +43,8 @@ class TestSelect(TestWidgetBase):
         }}, MultiSelectModel, Multiselect),
     ])
     def test_select(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)

--- a/test/models/widgets/test_texts.py
+++ b/test/models/widgets/test_texts.py
@@ -48,8 +48,8 @@ class TestText(TestWidgetBase):
         }}, ListModel, List),
     ])
     def test_text(self, input_data: dict, expected_model_cls, expected_widget_cls):
-        widget_model = self.yaml_model.from_data(input_data)
+        widget_model = self.yaml_model.create_model(input_data)
         assert isinstance(widget_model, expected_model_cls)
 
-        widget_obj = widget_model.get_obj()
+        widget_obj = widget_model.to_object()
         assert isinstance(widget_obj, expected_widget_cls)


### PR DESCRIPTION
- Separating the "factory" logic into an independent static class `YAMLModelFactory`
- Creating an abstract class `YAMLModel` for implementing models
- Inherit `WidgetsModels` from `YAMLModel`
- Correcting `YAMLModelFactory` integrations tests for new logic
- Fixed the display of some error messages